### PR TITLE
Update check_docker.sh

### DIFF
--- a/check_docker.sh
+++ b/check_docker.sh
@@ -156,7 +156,7 @@ function getstats () {
 			currentstats=`docker stats --no-stream | grep $cid | awk '{print $2}'`
 			;;
         	      MemPerc)
-			currentstats=`docker stats --no-stream | grep $cid | awk '{print $8}'`
+			currentstats=`docker stats --no-stream | grep $cid | awk '{print $7}'`
 			;;
 		      *)
             		echo "Unknown argument: $typestats"


### PR DESCRIPTION
The MemPerc awk field on my host is 7, not 8.. that was returning the amount of NET I/O in MB, instead of the Memory Percentage.. 

docker version 20.10.8, build 3967b7d from docker-ce/bionic